### PR TITLE
Add HTTP tests for API

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+)
+
+func setupRouter() *mux.Router {
+	r := mux.NewRouter()
+	registerRoutes(r)
+	return r
+}
+
+func TestHealthEndpoint(t *testing.T) {
+	router := setupRouter()
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rr := httptest.NewRecorder()
+
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status %d got %d", http.StatusOK, rr.Code)
+	}
+
+	var resp HealthCheckResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if resp.Status != "ok" {
+		t.Errorf("expected status 'ok' got '%s'", resp.Status)
+	}
+}
+
+func TestStatusEndpoint(t *testing.T) {
+	router := setupRouter()
+
+	req := httptest.NewRequest(http.MethodGet, "/status", nil)
+	rr := httptest.NewRecorder()
+
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status %d got %d", http.StatusOK, rr.Code)
+	}
+
+	var resp map[string]string
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if resp["network_status"] == "" {
+		t.Error("network_status should not be empty")
+	}
+	if resp["description"] == "" {
+		t.Error("description should not be empty")
+	}
+}


### PR DESCRIPTION

## Summary
- create `api/api_test.go` to test `/health` and `/status`

## Testing
- `make test`
___

### **PR Type**
Tests


___

### **Description**
- Add HTTP endpoint tests for `/health` and `/status`

- Validate response status codes and JSON structure

- Ensure non-empty fields in `/status` endpoint response


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api_test.go</strong><dd><code>Add tests for API health and status endpoints</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

api/api_test.go

<li>Introduced tests for <code>/health</code> and <code>/status</code> endpoints<br> <li> Used <code>httptest</code> to simulate HTTP requests and responses<br> <li> Verified response codes and decoded JSON bodies<br> <li> Checked for expected values and non-empty fields in responses


</details>


  </td>
  <td><a href="https://github.com/arec1b0/peochain-demo/pull/2/files#diff-f11bd9dcf3ad607c0a7bf74dc50ac921a34cd854a4087517e24ca377f4c0dfbe">+63/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>